### PR TITLE
feat: Add justfile and noxfile for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,51 @@ Install the extension with pip:
     ```
 
 You can add multiple CSS files to the static path and they will all converted into their own files.
+
+## Development & Testing
+
+This project uses `just` for common development tasks and `nox` for testing across multiple Python versions.
+
+### Quick Start with Just
+
+```bash
+# Run tests
+just test
+
+# Run tests with coverage
+just test-coverage
+
+# Run both (if available)
+just check
+```
+
+### Using Nox for Multi-Version Testing
+
+Test the plugin across Python 3.11, 3.12, 3.13, and 3.14:
+
+```bash
+# Run tests on all Python versions
+nox -s test
+
+# Run all checks
+nox -s check
+```
+
+### Development Setup
+
+```bash
+# Install with uv (recommended)
+uv sync
+
+# Install with pip
+pip install -e ".[test]"
+
+# Run tests
+just test
+```
+
+## Available Just Commands
+
+- `just test` - Run pytest on current Python version
+- `just test-coverage` - Run pytest with coverage reporting
+- `just check` - Run tests

--- a/justfile
+++ b/justfile
@@ -1,0 +1,11 @@
+_default:
+  just --list
+
+test:
+  uv run pytest tests/ -v
+
+test-coverage:
+  uv run pytest tests/ -v --cov=render_engine_tailwindcss --cov-report=term-out
+
+check:
+  just test

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,24 @@
+import nox
+import os
+
+# Test against these Python versions
+PYTHON_VERSIONS = ["3.11", "3.12", "3.13", "3.14"]
+
+# Use pyenv for locating Python interpreters
+os.environ["PYENV_VERSION"] = "3.11:3.12:3.13:3.14"
+nox.options.pythons = PYTHON_VERSIONS
+nox.options.reuse_existing_virtualenvs = True
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def test(session: nox.Session) -> None:
+    """Run tests with pytest."""
+    session.run("uv", "pip", "install", "-e", ".[dev]", external=True)
+    session.run("pytest", "tests/", "-v")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def check(session: nox.Session) -> None:
+    """Run tests."""
+    session.run("uv", "pip", "install", "-e", ".[dev]", external=True)
+    session.run("pytest", "tests/", "-v")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 dependencies = ["render-engine[cli]>=2024.11.2a1", "pytailwindcss"]
 
 [project.optional-dependencies]
+test = ["pytest"]
 dev = ["pytest"]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- Creates justfile with test and check commands
- Adds noxfile.py for testing across Python 3.11-3.14
- Updates README with development & testing documentation
- Adds test optional dependency to pyproject.toml

## Changes
- New justfile with convenient commands for testing
- New noxfile.py supporting Python 3.11, 3.12, 3.13, 3.14
- Updated README with development setup and command reference
- Added test optional dependency alongside dev for consistency

## Test plan
- Tests can be run with `just test`
- Multi-version testing available with `nox -s test`
- Coverage reporting available with `just test-coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)